### PR TITLE
Add Galera WSREP Provider

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,6 +16,22 @@ jobs:
     - run: make test
     - run: . ../release.sh
 
+  mariadb-104g:
+    working_directory: ~/repo/10
+    machine: true
+    environment:
+    - ALPINE_VER: "3.10"
+    - BASE_IMAGE_STABILITY_TAG: 2.4.3
+    - MARIADB_VER: 10.4.12
+    - GALERA_VER: 26.4.3
+    - TAGS: 10.4-galera,10-galera,galera
+    steps:
+    - checkout:
+        path: ~/repo
+    - run: make
+    - run: make test
+    - run: . ../release.sh
+
   mariadb-103:
     working_directory: ~/repo/10
     machine: true

--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -46,28 +46,41 @@ RUN set -xe; \
         readline-dev \
         zlib-dev; \
     \
-    apk add --update --no-cache -t .galera-build-deps \
-        boost-dev \
-        check-dev \
-        scons; \
-    \
     mariadb_url="https://downloads.mariadb.com/MariaDB/mariadb-${MARIADB_VER}/source/mariadb-${MARIADB_VER}.tar.gz"; \
-    galera_url="https://github.com/codership/galera/archive/release_${GALERA_VER}.tar.gz"; \
     curl -fSL "${mariadb_url}" -o /tmp/mariadb.tar.gz; \
     curl -fSL "${mariadb_url}.asc" -o /tmp/mariadb.tar.gz.asc; \
-    curl -fSL "${galera_url}" -o /tmp/galera.tar.gz; \
     GPG_KEYS="199369E5404BD5FC7D2FE43BCBCB082A1BB943DB;430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A;4D1BB29D63D98E422B2113B19334A25F8507EFA5" gpg_verify /tmp/mariadb.tar.gz.asc /tmp/mariadb.tar.gz; \
     \
     tar zxf /tmp/mariadb.tar.gz -C /tmp; \
-    tar zxf /tmp/galera.tar.gz -C /tmp; \
-    rmdir "/tmp/galera-release_${GALERA_VER}/wsrep/src"; \
-    ln -s "/tmp/mariadb-${MARIADB_VER}/wsrep-lib/wsrep-API/v${WSREP_VER}" "/tmp/galera-release_${GALERA_VER}/wsrep/src"; \
+    #
+    # Optional Galera Build/Install
+    #
+    if [ -n "${GALERA_VER}" ]; then \
+        apk add --update --no-cache -t .galera-build-deps \
+            boost-dev \
+            check-dev \
+            scons; \
+        galera_url="https://github.com/codership/galera/archive/release_${GALERA_VER}.tar.gz"; \
+        curl -fSL "${galera_url}" -o /tmp/galera.tar.gz; \
+        tar zxf /tmp/galera.tar.gz -C /tmp; \
+        rmdir "/tmp/galera-release_${GALERA_VER}/wsrep/src"; \
+        ln -s "/tmp/mariadb-${MARIADB_VER}/wsrep-lib/wsrep-API/v${WSREP_VER}" "/tmp/galera-release_${GALERA_VER}/wsrep/src"; \
+        \
+        cd "/tmp/galera-release_${GALERA_VER}"; \
+        for i in /tmp/patches/galera/"${GALERA_VER:0:4}"/*.patch; do patch -p1 -i "${i}"; done; \
+        RUN_TESTS=0 scripts/build.sh -j "${NPROC:-$(nproc)}"; \
+        apk del --purge .galera-build-deps; \
+        \
+        mkdir -p /usr/lib/galera; \
+        cp -a "/tmp/galera-release_${GALERA_VER}/libgalera_smm.so" /usr/lib/galera; \
+        chown -R mysql:mysql /usr/lib/galera; \
+        \
+        cp -a "/tmp/galera-release_${GALERA_VER}/garb/garbd" /usr/sbin; \
+    fi; \
     \
-    cd "/tmp/galera-release_${GALERA_VER}"; \
-    for i in /tmp/patches/galera/"${GALERA_VER:0:4}"/*.patch; do patch -p1 -i "${i}"; done; \
-    RUN_TESTS=0 scripts/build.sh -j "${NPROC:-$(nproc)}"; \
-    apk del --purge .galera-build-deps; \
-    \
+    #
+    # MariaDB Build
+    #
     cd "/tmp/mariadb-${MARIADB_VER}"; \
     # From alpine repository https://git.alpinelinux.org/cgit/aports/tree/main/mariadb?h=3.6-stable
     for i in /tmp/patches/"${MARIADB_VER:0:4}"/*.patch; do patch -p1 -i "${i}"; done; \
@@ -149,12 +162,9 @@ RUN set -xe; \
     find /usr/lib -name '*.a' -maxdepth 1 -print0 | xargs -0 rm; \
     find /usr/lib -name '*.so' -type l -maxdepth 1 -print0 | xargs -0 rm; \
     \
-    # install Galera wsrep provider library
-    cp "/tmp/galera-release_${GALERA_VER}/libgalera_smm.so" /usr/lib; \
-    \
     # Stripping binaries and .so files.
     scanelf --symlink --recursive --nobanner --osabi --etype "ET_DYN,ET_EXEC" \
-        /usr/bin/* /usr/lib/mysql/plugin/* /usr/lib/libgalera_smm.so | while read type osabi filename; do \
+        /usr/bin/* /usr/sbin/* /usr/lib/mysql/plugin/* /usr/lib/galera/* | while read type osabi filename; do \
         ([ "$osabi" != "STANDALONE" ] && [ "${filename}" != "/usr/bin/strip" ]) || continue; \
         XATTR=$(getfattr --match="" --dump "${filename}"); \
         strip "${filename}"; \

--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -57,6 +57,7 @@ RUN set -xe; \
     #
     if [ -n "${GALERA_VER}" ]; then \
         apk add --update --no-cache -t .galera-run-deps \
+            boost-program_options \
             rsync \
             socat; \
         apk add --update --no-cache -t .galera-build-deps \

--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -56,6 +56,9 @@ RUN set -xe; \
     # Optional Galera Build/Install
     #
     if [ -n "${GALERA_VER}" ]; then \
+        apk add --update --no-cache -t .galera-run-deps \
+            rsync \
+            socat; \
         apk add --update --no-cache -t .galera-build-deps \
             boost-dev \
             check-dev \

--- a/10/Dockerfile
+++ b/10/Dockerfile
@@ -3,8 +3,12 @@ ARG BASE_IMAGE_TAG
 FROM wodby/alpine:${BASE_IMAGE_TAG}
 
 ARG MARIADB_VER
+ARG GALERA_VER
+ARG WSREP_VER
+ARG NPROC
 
 ENV MARIADB_VER="${MARIADB_VER}" \
+    GALERA_VER="${GALERA_VER}" \
     BACKUPS_DIR="/mnt/backups"
 
 COPY patches /tmp/patches
@@ -12,8 +16,8 @@ COPY patches /tmp/patches
 RUN set -xe; \
     \
     addgroup -g 101 -S mysql; \
-	adduser -u 100 -D -S -s /bin/bash -G mysql mysql; \
-	echo "PS1='\w\$ '" >> /home/mysql/.bashrc; \
+    adduser -u 100 -D -S -s /bin/bash -G mysql mysql; \
+    echo "PS1='\w\$ '" >> /home/mysql/.bashrc; \
     \
     apk add --update --no-cache -t .mariadb-run-deps \
         libaio \
@@ -42,12 +46,28 @@ RUN set -xe; \
         readline-dev \
         zlib-dev; \
     \
+    apk add --update --no-cache -t .galera-build-deps \
+        boost-dev \
+        check-dev \
+        scons; \
+    \
     mariadb_url="https://downloads.mariadb.com/MariaDB/mariadb-${MARIADB_VER}/source/mariadb-${MARIADB_VER}.tar.gz"; \
+    galera_url="https://github.com/codership/galera/archive/release_${GALERA_VER}.tar.gz"; \
     curl -fSL "${mariadb_url}" -o /tmp/mariadb.tar.gz; \
     curl -fSL "${mariadb_url}.asc" -o /tmp/mariadb.tar.gz.asc; \
+    curl -fSL "${galera_url}" -o /tmp/galera.tar.gz; \
     GPG_KEYS="199369E5404BD5FC7D2FE43BCBCB082A1BB943DB;430BDF5C56E7C94E848EE60C1C4CBDCDCD2EFD2A;4D1BB29D63D98E422B2113B19334A25F8507EFA5" gpg_verify /tmp/mariadb.tar.gz.asc /tmp/mariadb.tar.gz; \
     \
     tar zxf /tmp/mariadb.tar.gz -C /tmp; \
+    tar zxf /tmp/galera.tar.gz -C /tmp; \
+    rmdir "/tmp/galera-release_${GALERA_VER}/wsrep/src"; \
+    ln -s "/tmp/mariadb-${MARIADB_VER}/wsrep-lib/wsrep-API/v${WSREP_VER}" "/tmp/galera-release_${GALERA_VER}/wsrep/src"; \
+    \
+    cd "/tmp/galera-release_${GALERA_VER}"; \
+    for i in /tmp/patches/galera/"${GALERA_VER:0:4}"/*.patch; do patch -p1 -i "${i}"; done; \
+    RUN_TESTS=0 scripts/build.sh -j "${NPROC:-$(nproc)}"; \
+    apk del --purge .galera-build-deps; \
+    \
     cd "/tmp/mariadb-${MARIADB_VER}"; \
     # From alpine repository https://git.alpinelinux.org/cgit/aports/tree/main/mariadb?h=3.6-stable
     for i in /tmp/patches/"${MARIADB_VER:0:4}"/*.patch; do patch -p1 -i "${i}"; done; \
@@ -86,7 +106,7 @@ RUN set -xe; \
     		-DWITHOUT_FEDERATED_STORAGE_ENGINE=1 \
     		-DWITHOUT_PBXT_STORAGE_ENGINE=1; \
     \
-    make -j "$(nproc)"; \
+    make -j "${NPROC:-$(nproc)}"; \
     make install; \
     \
     # Script to fix volumes permissions via sudo.
@@ -129,9 +149,12 @@ RUN set -xe; \
     find /usr/lib -name '*.a' -maxdepth 1 -print0 | xargs -0 rm; \
     find /usr/lib -name '*.so' -type l -maxdepth 1 -print0 | xargs -0 rm; \
     \
+    # install Galera wsrep provider library
+    cp "/tmp/galera-release_${GALERA_VER}/libgalera_smm.so" /usr/lib; \
+    \
     # Stripping binaries and .so files.
     scanelf --symlink --recursive --nobanner --osabi --etype "ET_DYN,ET_EXEC" \
-        /usr/bin/* /usr/lib/mysql/plugin/* | while read type osabi filename; do \
+        /usr/bin/* /usr/lib/mysql/plugin/* /usr/lib/libgalera_smm.so | while read type osabi filename; do \
         ([ "$osabi" != "STANDALONE" ] && [ "${filename}" != "/usr/bin/strip" ]) || continue; \
         XATTR=$(getfattr --match="" --dump "${filename}"); \
         strip "${filename}"; \

--- a/10/Makefile
+++ b/10/Makefile
@@ -3,7 +3,12 @@
 MARIADB_VER ?= 10.4.12
 MARIADB_VER_MINOR = $(shell echo "${MARIADB_VER}" | grep -oE '^[0-9]+\.[0-9]+')
 
-ALPINE_VER ?= 3.10
+GALERA_VER ?= 26.4.3
+WSREP_VER = $(shell echo "${GALERA_VER}" | grep -oE '^[0-9]+')
+
+ALPINE_VER ?= 3.11
+
+NPROC =
 
 ifeq ($(BASE_IMAGE_STABILITY_TAG),)
     BASE_IMAGE_TAG := $(ALPINE_VER)
@@ -30,7 +35,10 @@ default: build
 build:
 	docker build -t $(REPO):$(TAG) \
 	    --build-arg BASE_IMAGE_TAG=$(BASE_IMAGE_TAG) \
-	    --build-arg MARIADB_VER=$(MARIADB_VER) ./
+	    --build-arg MARIADB_VER=$(MARIADB_VER) \
+	    --build-arg GALERA_VER=$(GALERA_VER) \
+	    --build-arg WSREP_VER=$(WSREP_VER) \
+	    --build-arg NPROC=$(NPROC) ./
 
 test:
 	cd ./tests && IMAGE=$(REPO):$(TAG) ./run.sh

--- a/10/Makefile
+++ b/10/Makefile
@@ -3,10 +3,10 @@
 MARIADB_VER ?= 10.4.12
 MARIADB_VER_MINOR = $(shell echo "${MARIADB_VER}" | grep -oE '^[0-9]+\.[0-9]+')
 
-GALERA_VER ?= 26.4.3
-WSREP_VER = $(shell echo "${GALERA_VER}" | grep -oE '^[0-9]+')
+GALERA_VER ?=
+WSREP_VER ?= $(shell echo "${GALERA_VER}" | grep -oE '^[0-9]+')
 
-ALPINE_VER ?= 3.11
+ALPINE_VER ?= 3.10
 
 NPROC =
 

--- a/10/patches/galera/26.4/musl-page-size.patch
+++ b/10/patches/galera/26.4/musl-page-size.patch
@@ -1,0 +1,15 @@
+--- a/galerautils/src/gu_alloc.cpp
++++ b/galerautils/src/gu_alloc.cpp
+@@ -29,10 +29,11 @@
+     if (gu_likely(size <= left_))
+     {
+         /* to avoid too frequent allocation, make it (at least) 64K */
+-        static page_size_type const PAGE_SIZE(gu_page_size_multiple(1 << 16));
++	/* was PAGE_SIZE but collided with a define */
++        static page_size_type const PG_SZ(gu_page_size_multiple(1 << 16));
+
+         page_size_type const page_size
+-            (std::min(std::max(size, PAGE_SIZE), left_));
++            (std::min(std::max(size, PG_SZ), left_));
+
+         Page* ret = new HeapPage (page_size);

--- a/10/patches/galera/26.4/musl-sched_param.patch
+++ b/10/patches/galera/26.4/musl-sched_param.patch
@@ -1,0 +1,12 @@
+--- a/galerautils/src/gu_thread.cpp
++++ b/galerautils/src/gu_thread.cpp
+@@ -87,7 +87,8 @@
+ #if defined(__sun__)
+     struct sched_param spstr = { sp.prio(), { 0, } /* sched_pad array */};
+ #else
+-    struct sched_param spstr = { sp.prio() };
++    /* musl has some reserved fields in sched_param... */
++    struct sched_param spstr = { sp.prio(), 0, 0, 0, 0, 0, 0 };
+ #endif
+     int err;
+     if ((err = pthread_setschedparam(thd, sp.policy(), &spstr)) != 0)

--- a/10/patches/galera/26.4/musl-sys-poll-h.patch
+++ b/10/patches/galera/26.4/musl-sys-poll-h.patch
@@ -1,0 +1,11 @@
+--- a/asio/asio/detail/socket_types.hpp
++++ b/asio/asio/detail/socket_types.hpp
+@@ -58,7 +58,7 @@
+ #else
+ # include <sys/ioctl.h>
+ # if !defined(__SYMBIAN32__)
+-#  include <sys/poll.h>
++#  include <poll.h>	/* avoid "redirecting incorrect #include <sys/poll.h> to <poll.h>" warning */
+ # endif
+ # include <sys/types.h>
+ # include <sys/stat.h>

--- a/10/patches/galera/26.4/musl-wordsize.patch
+++ b/10/patches/galera/26.4/musl-wordsize.patch
@@ -1,0 +1,13 @@
+--- a/galerautils/src/gu_arch.h
++++ b/galerautils/src/gu_arch.h
+@@ -50,8 +50,9 @@
+ #elif defined(__APPLE__) || defined(__FreeBSD__)
+ # include <stdint.h>
+ # define GU_WORDSIZE __WORDSIZE
+-#else
+-# include <bits/wordsize.h>
++#else /* use this instead of bits/wordsize.h */
++# include <stdint.h>
++# include <bits/user.h>
+ # define GU_WORDSIZE __WORDSIZE
+ #endif

--- a/10/templates/10.4/my.cnf.tmpl
+++ b/10/templates/10.4/my.cnf.tmpl
@@ -13,10 +13,10 @@ port                                    = {{ getenv "MYSQL_PORT" "3306" }}
 socket                                  = /var/run/mysqld/mysqld.sock
 default-character-set                   = {{ getenv "MYSQL_CLIENT_DEFAULT_CHARACTER_SET" "utf8" }}
 
-{{ if getenv "MARIADB_PLUGIN_LOAD" }}
+{{- if getenv "MARIADB_PLUGIN_LOAD" }}
 [mariadb]
 plugin_load                             = {{ getenv "MARIADB_PLUGIN_LOAD" }}
-{{ end }}
+{{- end }}
 
 [mysqld]
 user                                    = mysql
@@ -33,7 +33,11 @@ character_set_server                    = {{ getenv "MYSQL_CHARACTER_SET_SERVER"
 character_set_filesystem                = {{ getenv "MYSQL_CHARACTER_SET_FILESYSTEM" "utf8" }}
 
 symbolic-links                          = 0
+{{- if getenv "WSREP_ON" }}
+default_storage_engine                  = InnoDB
+{{- else }}
 default_storage_engine                  = {{ getenv "MYSQL_DEFAULT_STORAGE_ENGINE" "InnoDB" }}
+{{- end }}
 
 skip-character-set-client-handshake
 skip-name-resolve
@@ -63,7 +67,11 @@ innodb_data_file_path                   = {{ getenv "MYSQL_INNODB_DATA_FILE_PATH
 innodb_default_row_format               = {{ getenv "MYSQL_INNODB_DEFAULT_ROW_FORMAT" "dynamic" }}
 innodb_fast_shutdown                    = {{ getenv "MYSQL_INNODB_FAST_SHUTDOWN" "1" }}
 innodb_file_per_table                   = {{ getenv "MYSQL_INNODB_FILE_PER_TABLE" "1" }}
+{{- if getenv "WSREP_ON" }}
+innodb_flush_log_at_trx_commit          = {{ getenv "MYSQL_INNODB_FLUSH_LOG_AT_TRX_COMMIT" "0" }}
+{{- else }}
 innodb_flush_log_at_trx_commit          = {{ getenv "MYSQL_INNODB_FLUSH_LOG_AT_TRX_COMMIT" "2" }}
+{{- end }}
 innodb_flush_method                     = {{ getenv "MYSQL_INNODB_FLUSH_METHOD" "O_DIRECT" }}
 innodb_force_load_corrupted             = {{ getenv "MYSQL_INNODB_FORCE_LOAD_CORRUPTED" "0" }}
 innodb_force_recovery                   = {{ getenv "MYSQL_INNODB_FORCE_RECOVERY" "0" }}
@@ -99,3 +107,79 @@ optimizer_prune_level                   = {{ getenv "MYSQL_OPTIMIZER_PRUNE_LEVEL
 optimizer_search_depth                  = {{ getenv "MYSQL_OPTIMIZER_SEARCH_DEPTH" "62" }}
 
 transaction-isolation                   = {{ getenv "MYSQL_TRANSACTION_ISOLATION" "REPEATABLE-READ" }}
+{{- if getenv "WSREP_ON" }}
+
+
+wsrep_on                                = {{ getenv "WSREP_ON" }}
+wsrep_provider                          = "/usr/lib/galera/libgalera_smm.so"
+{{- if getenv "WSREP_PROVIDER_OPTIONS" }}
+wsrep_provider_options                  = {{ getenv "WSREP_PROVIDER_OPTIONS" }}
+{{- end }}
+
+binlog_format                           = ROW
+innodb_autoinc_lock_mode                = 2
+
+{{- if getenv "WSREP_CLUSTER_ADDRESS" }}
+wsrep_cluster_address                   = {{ getenv "WSREP_CLUSTER_ADDRESS" }}
+{{- end }}
+wsrep_cluster_name                      = {{ getenv "WSREP_CLUSTER_NAME" "my_wsrep_cluster" }}
+wsrep_node_address                      = {{ getenv "WSREP_NODE_ADDRESS" "0.0.0.0" }}
+wsrep_node_incoming_address             = {{ getenv "WSREP_NODE_INCOMING_ADDRESS" "AUTO" }}
+{{- if getenv "WSREP_NODE_NAME" }}
+wsrep_node_name                         = {{ getenv "WSREP_NODE_NAME" }}
+{{- end }}
+{{- if getenv "WSREP_DATA_HOME_DIR" }}
+wsrep_data_home_dir                     = {{ getenv "WSREP_DATA_HOME_DIR" }}
+{{- end }}
+{{- if getenv "WSREP_RECOVER" }}
+wsrep_recover                           = {{ getenv "WSREP_RECOVER" }}
+{{- end }}
+{{- if getenv "WSREP_START_POSITION" }}
+wsrep_start_position                    = {{ getenv "WSREP_START_POSITION" }}
+{{- end }}
+
+wsrep_auto_increment_control            = {{ getenv "WSREP_AUTO_INCREMENT_CONTROL" "ON" }}
+wsrep_certification_rules               = {{ getenv "WSREP_CERTIFICATION_RULES" "strict" }}
+wsrep_certify_nonPK                     = {{ getenv "WSREP_CERTIFY_NONPK" "ON" }}
+wsrep_convert_LOCK_to_trx               = {{ getenv "WSREP_CONVERT_LOCK_TO_TRX" "OFF" }}
+{{- if getenv "WSREP_DBUG_OPTION" }}
+wsrep_dbug_option                       = {{ getenv "WSREP_DBUG_OPTION" }}
+{{- end }}
+wsrep_debug                             = {{ getenv "WSREP_DEBUG" "NONE" }}
+wsrep_desync                            = {{ getenv "WSREP_DESYNC" "OFF" }}
+wsrep_dirty_reads                       = {{ getenv "WSREP_DIRTY_READS" "OFF" }}
+wsrep_drupal_282555_workaround          = {{ getenv "WSREP_DRUPAL_282555_WORKAROUND" "OFF" }}
+wsrep_forced_binlog_format              = {{ getenv "WSREP_FORCED_BINLOG_FORMAT" "NONE" }}
+wsrep_gtid_domain_id                    = {{ getenv "WSREP_GTID_DOMAIN_ID" "0" }}
+wsrep_gtid_mode                         = {{ getenv "WSREP_GTID_MODE" "OFF" }}
+wsrep_ignore_apply_errors               = {{ getenv "WSREP_IGNORE_APPLY_ERRORS" "0" }}
+wsrep_load_data_splitting               = {{ getenv "WSREP_LOAD_DATA_SPLITTING" "OFF" }}
+wsrep_log_conflicts                     = {{ getenv "WSREP_LOG_CONFLICTS" "OFF" }}
+wsrep_max_ws_rows                       = {{ getenv "WSREP_MAX_WS_ROWS" "0" }}
+wsrep_max_ws_size                       = {{ getenv "WSREP_MAX_WS_SIZE" "2G" }}
+wsrep_mysql_replication_bundle          = {{ getenv "WSREP_MYSQL_REPLICATION_BUNDLE" "0" }}
+{{- if getenv "WSREP_NOTIFY_CMD" }}
+wsrep_notify_cmd                        = {{ getenv "WSREP_NOTIFY_CMD" }}
+{{- end }}
+wsrep_OSU_method                        = {{ getenv "WSREP_OSU_METHOD" "TOI" }}
+wsrep_reject_queries                    = {{ getenv "WSREP_REJECT_QUERIES" "NONE" }}
+wsrep_replicate_myisam                  = {{ getenv "WSREP_REPLICATE_MYISAM" "OFF" }}
+wsrep_restart_slave                     = {{ getenv "WSREP_RESTART_SLAVE" "OFF" }}
+wsrep_retry_autocommit                  = {{ getenv "WSREP_RETRY_AUTOCOMMIT" "1" }}
+wsrep_slave_FK_checks                   = {{ getenv "WSREP_SLAVE_FK_CHECKS" "ON" }}
+wsrep_slave_threads                     = {{ getenv "WSREP_SLAVE_THREADS" "1" }}
+wsrep_slave_UK_checks                   = {{ getenv "WSREP_SLAVE_UK_CHECKS" "OFF" }}
+wsrep_sr_store                          = {{ getenv "WSREP_SR_STORE" "table" }}
+{{- if getenv "WSREP_SST_AUTH" }}
+wsrep_sst_auth                          = {{ getenv "WSREP_SST_AUTH" }}
+{{- end }}
+{{- if getenv "WSREP_SST_AUTH" }}
+wsrep_sst_donor                         = {{ getenv "WSREP_SST_DONOR" }}
+{{- end }}
+wsrep_sst_donor_rejects_queries         = {{ getenv "WSREP_SST_DONOR_REJECTS_QUERIES" "OFF" }}
+wsrep_sst_method                        = {{ getenv "WSREP_SST_METHOD" "rsync" }}
+wsrep_sst_receive_address               = {{ getenv "WSREP_RECEIVE_ADDRESS" "AUTO" }}
+wsrep_sync_wait                         = {{ getenv "WSREP_SYNC_WAIT" "0" }}
+wsrep_trx_fragment_size                 = {{ getenv "WSREP_TRX_FRAGMENT_SIZE" "0" }}
+wsrep_trx_fragment_unit                 = {{ getenv "WSREP_TRX_FRAGMENT_UNIT" "bytes" }}
+{{- end }}

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ❗Known issue with bind mounts on macOS and Windows
 
-Latest MariaDB will fail to start on macOS and Windows with `Probably out of disk space` if you **use bind mounts** (volumes mounted from host). This (likely) happens because of recent changes in InnoDB, this bug addressed in [MariaDB JIRA](https://jira.mariadb.org/browse/MDEV-16015). 
+Latest MariaDB will fail to start on macOS and Windows with `Probably out of disk space` if you **use bind mounts** (volumes mounted from host). This (likely) happens because of recent changes in InnoDB, this bug addressed in [MariaDB JIRA](https://jira.mariadb.org/browse/MDEV-16015).
 
 Solutions:
 
@@ -16,13 +16,13 @@ Solutions:
 
 ## Docker Images
 
-❗For better reliability we release images with stability tags (`wodby/mariadb:10.4-X.X.X`) which correspond to [git tags](https://github.com/wodby/mariadb/releases). We strongly recommend using images only with stability tags. 
+❗For better reliability we release images with stability tags (`wodby/mariadb:10.4-X.X.X`) which correspond to [git tags](https://github.com/wodby/mariadb/releases). We strongly recommend using images only with stability tags.
 
 Overview:
 
 * All images are based on Alpine Linux
 * Base image: [wodby/alpine](https://github.com/wodby/alpine)
-* [CircleCI builds](https://circleci.com/gh/wodby/mariadb) 
+* [CircleCI builds](https://circleci.com/gh/wodby/mariadb)
 * [Docker Hub](https://hub.docker.com/r/wodby/mariadb)
 
 Supported tags and respective `Dockerfile` links:
@@ -32,7 +32,7 @@ Supported tags and respective `Dockerfile` links:
 * `10.2` [_(Dockerfile)_](https://github.com/wodby/mariadb/tree/master/10/Dockerfile)
 * `10.1` [_(Dockerfile)_](https://github.com/wodby/mariadb/tree/master/10/Dockerfile)
 
-Credits to Alpine Linux team for patches for better musl compatibility of MariaDB. Patches taken from Alpine's [packages repository](https://pkgs.alpinelinux.org/packages). 
+Credits to Alpine Linux team for patches for better musl compatibility of MariaDB. Patches taken from Alpine's [packages repository](https://pkgs.alpinelinux.org/packages).
 
 ## Environment Variables
 
@@ -116,6 +116,64 @@ Default value for all versions:
 ibdata1:10M:autoextend:max:10G"
 ```
 
+### Additional Galera environment variables
+
+| Variable                                  | 10.4-galera         |
+| ----------------------------------------- | ------------------- |
+| [`WSREP_ON`]                              | `OFF`               |
+| [`MYSQL_INNODB_FLUSH_LOG_AT_TRX_COMMIT`]  | `0`                 |
+| [`WSREP_AUTO_INCREMENT_CONTROL`]          | `ON`                |
+| [`WSREP_CERTIFICATION_RULES`]             | `strict`            |
+| [`WSREP_CERTIFY_NONPK`]                   | `ON`                |
+| [`WSREP_CLUSTER_ADDRESS`]                 |                     |
+| [`WSREP_CLUSTER_NAME`]                    | `my_wsrep_cluster`  |
+| [`WSREP_CONVERT_LOCK_TO_TRX`]             | `OFF`               |
+| [`WSREP_DATA_HOME_DIR`]                   |                     |
+| [`WSREP_DBUG_OPTION`]                     |                     |
+| [`WSREP_DEBUG`]                           | `NONE`              |
+| [`WSREP_DESYNC`]                          | `OFF`               |
+| [`WSREP_DIRTY_READS`]                     | `OFF`               |
+| [`WSREP_DRUPAL_282555_WORKAROUND`]        | `OFF`               |
+| [`WSREP_FORCED_BINLOG_FORMAT`]            | `NONE`              |
+| [`WSREP_GTID_DOMAIN_ID`]                  | `0`                 |
+| [`WSREP_GTID_MODE`]                       | `OFF`               |
+| [`WSREP_IGNORE_APPLY_ERRORS`]             | `0`                 |
+| [`WSREP_LOAD_DATA_SPLITTING`]             | `OFF`               |
+| [`WSREP_LOG_CONFLICTS`]                   | `OFF`               |
+| [`WSREP_MAX_WS_ROWS`]                     | `0`                 |
+| [`WSREP_MAX_WS_SIZE`]                     | `2G`                |
+| [`WSREP_MYSQL_REPLICATION_BUNDLE`]        | `0`                 |
+| [`WSREP_NODE_ADDRESS`]                    | `0.0.0.0`           |
+| [`WSREP_NODE_INCOMING_ADDRESS`]           | `AUTO`              |
+| [`WSREP_NODE_NAME`]                       |                     |
+| [`WSREP_NOTIFY_CMD`]                      |                     |
+| [`WSREP_OSU_METHOD`]                      | `TOI`               |
+| [`WSREP_PROVIDER_OPTIONS`]                |                     |
+| [`WSREP_RECOVER`]                         | `OFF`               |
+| [`WSREP_REJECT_QUERIES`]                  | `NONE`              |
+| [`WSREP_REPLICATE_MYISAM`]                | `OFF`               |
+| [`WSREP_RESTART_SLAVE`]                   | `OFF`               |
+| [`WSREP_RETRY_AUTOCOMMIT`]                | `1`                 |
+| [`WSREP_SLAVE_FK_CHECKS`]                 | `ON`                |
+| [`WSREP_SLAVE_THREADS`]                   | `1`                 |
+| [`WSREP_SLAVE_UK_CHECKS`]                 | `OFF`               |
+| [`WSREP_SR_STORE`]                        | `table`             |
+| [`WSREP_SST_AUTH`]                        |                     |
+| [`WSREP_SST_DONOR`]                       |                     |
+| [`WSREP_SST_DONOR_REJECTS_QUERIES`]       | `OFF`               |
+| [`WSREP_SST_METHOD`]                      | `rsync`             |
+| [`WSREP_RECEIVE_ADDRESS`]                 | `AUTO`              |
+| [`WSREP_START_POSITION`]                  |                     |
+| [`WSREP_SYNC_WAIT`]                       | `0`                 |
+| [`WSREP_TRX_FRAGMENT_SIZE`]               | `0`                 |
+| [`WSREP_TRX_FRAGMENT_UNIT`]               | `bytes`             |
+
+| Galera Config Directive    | Override |
+| -------------------------- | -------- |
+| `binlog_format`            | `ROW`    |
+| `default_storage_engine`   | `InnoDB` |
+| `innodb_autoinc_lock_mode` | `2`      |
+
 ## Performance Tuning Recommendations
 
 ### Optimizer search depth
@@ -148,17 +206,17 @@ Source: from [stack exchange](https://dba.stackexchange.com/a/27472/134547).
 Usage:
 ```
 make COMMAND [params ...]
- 
+
 commands:
-    import source=</path/to/dump.zip or http://example.com/url/to/dump.sql.gz> [db root_password host ignore="table1;table2;cache_%"] 
-    backup filepath=</path/to/backup.sql.gz> [root_password host db] 
-    query query [db user password host] 
-    query-silent query [db user password host] 
+    import source=</path/to/dump.zip or http://example.com/url/to/dump.sql.gz> [db root_password host ignore="table1;table2;cache_%"]
+    backup filepath=</path/to/backup.sql.gz> [root_password host db]
+    query query [db user password host]
+    query-silent query [db user password host]
     query-root query [db root_password host]
     check-ready [root_password host max_try wait_seconds]  
     mysql-upgrade [root_password host]  
     mysql-check [root_password host db]  
-    
+
 default params values:
     user $MYSQL_USER
     password $MYSQL_PASSWORD
@@ -177,8 +235,8 @@ Deploy MariaDB to your own server via [![Wodby](https://www.google.com/s2/favico
 
 [`MARIADB_PLUGIN_LOAD`]: https://mariadb.com/kb/en/library/plugin-overview/#installing-a-plugin-with-plugin-load
 [`MYSQL_BACK_LOG`]: https://mariadb.com/kb/en/library/server-system-variables#back_log
-[`MYSQL_CHARACTER_SET_FILESYSTEM`]: https://mariadb.com/kb/en/library/server-system-variables#character_set_filesystem 
-[`MYSQL_CHARACTER_SET_SERVER`]: https://mariadb.com/kb/en/library/server-system-variables#character_set_server 
+[`MYSQL_CHARACTER_SET_FILESYSTEM`]: https://mariadb.com/kb/en/library/server-system-variables#character_set_filesystem
+[`MYSQL_CHARACTER_SET_SERVER`]: https://mariadb.com/kb/en/library/server-system-variables#character_set_server
 [`MYSQL_COLLATION_SERVER`]: https://mariadb.com/kb/en/library/server-system-variables#collation_server
 [`MYSQL_CONNECT_TIMEOUT`]: https://mariadb.com/kb/en/library/server-system-variables/#connect_timeout
 [`MYSQL_DEFAULT_STORAGE_ENGINE`]: https://mariadb.com/kb/en/library/server-system-variables#default_storage_engine
@@ -235,3 +293,49 @@ Deploy MariaDB to your own server via [![Wodby](https://www.google.com/s2/favico
 [`MYSQL_TMP_TABLE_SIZE`]: https://mariadb.com/kb/en/library/server-system-variables#tmp_table_size
 [`MYSQL_WAIT_TIMEOUT`]: https://mariadb.com/kb/en/library/server-system-variables#wait_timeout
 [`MYSQL_TRANSACTION_ISOLATION`]: https://mariadb.com/kb/en/library/server-system-variables#tx_isolation
+[`WSREP_ON`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_on
+[`WSREP_AUTO_INCREMENT_CONTROL`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_auto_increment_control
+[`WSREP_CERTIFICATION_RULES`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_certification_rules
+[`WSREP_CERTIFY_NONPK`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_certify_nonpk
+[`WSREP_CLUSTER_ADDRESS`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_cluster_address
+[`WSREP_CLUSTER_NAME`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_cluster_name
+[`WSREP_CONVERT_LOCK_TO_TRX`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_convert_lock_to_trx
+[`WSREP_DATA_HOME_DIR`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_data_home_dir
+[`WSREP_DBUG_OPTION`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_dbug_option
+[`WSREP_DEBUG`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_debug
+[`WSREP_DESYNC`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_desync
+[`WSREP_DIRTY_READS`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_dirty_reads
+[`WSREP_DRUPAL_282555_WORKAROUND`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_drupal_282555_workaround
+[`WSREP_FORCED_BINLOG_FORMAT`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_forced_binlog_format
+[`WSREP_GTID_DOMAIN_ID`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_gtid_domain_id
+[`WSREP_GTID_MODE`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_gtid_mode
+[`WSREP_IGNORE_APPLY_ERRORS`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_ignore_apply_errors
+[`WSREP_LOAD_DATA_SPLITTING`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_load_data_splitting
+[`WSREP_LOG_CONFLICTS`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_log_conflicts
+[`WSREP_MAX_WS_ROWS`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_max_ws_rows
+[`WSREP_MAX_WS_SIZE`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_max_ws_size
+[`WSREP_MYSQL_REPLICATION_BUNDLE`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_mysql_replication_bundle
+[`WSREP_NODE_ADDRESS`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_node_address
+[`WSREP_NODE_INCOMING_ADDRESS`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_node_incoming_address
+[`WSREP_NODE_NAME`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_node_name
+[`WSREP_NOTIFY_CMD`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_notify_cmd
+[`WSREP_OSU_METHOD`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_osu_method
+[`WSREP_PROVIDER_OPTIONS`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_provider_options
+[`WSREP_RECOVER`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_recover
+[`WSREP_REJECT_QUERIES`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_reject_queries
+[`WSREP_REPLICATE_MYISAM`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_replicate_myisam
+[`WSREP_RESTART_SLAVE`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_restart_slave
+[`WSREP_RETRY_AUTOCOMMIT`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_retry_autocommit
+[`WSREP_SLAVE_FK_CHECKS`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_slave_fk_checks
+[`WSREP_SLAVE_THREADS`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_slave_threads
+[`WSREP_SLAVE_UK_CHECKS`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_slave_uk_checks
+[`WSREP_SR_STORE`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_sr_store
+[`WSREP_SST_AUTH`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_sst_auth
+[`WSREP_SST_DONOR`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_sst_donor
+[`WSREP_SST_DONOR_REJECTS_QUERIES`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_sst_donor_rejects_queries
+[`WSREP_SST_METHOD`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_sst_method
+[`WSREP_RECEIVE_ADDRESS`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_sst_receive_address
+[`WSREP_START_POSITION`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_start_position
+[`WSREP_SYNC_WAIT`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_sync_wait
+[`WSREP_TRX_FRAGMENT_SIZE`]: https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_trx_fragment_size
+[`WSREP_TRX_FRAGMENT_UNIT`]:  https://mariadb.com/kb/en/galera-cluster-system-variables/#wsrep_trx_fragment_unit


### PR DESCRIPTION
* download, patch, build, install, and strip Galera WSREP Provider
* patches allow Galera to build on Alpine/musl for x86/x86_64 architectures (patches would need tweaks to support other arch's)
* adds NPROC make variable (my builds were unstable with `-j $(nproc)`)
* set default ALPINE_VER to 3.11