### PR TITLE
feat: add lower_case_table_names property configuration

### DIFF
--- a/10/templates/10.2/my.cnf.tmpl
+++ b/10/templates/10.2/my.cnf.tmpl
@@ -41,6 +41,8 @@ init_connect                            = '{{ getenv "MYSQL_INIT_CONNECT" "SET N
 character_set_server                    = {{ getenv "MYSQL_CHARACTER_SET_SERVER" "utf8" }}
 character_set_filesystem                = {{ getenv "MYSQL_CHARACTER_SET_FILESYSTEM" "utf8" }}
 
+lower_case_table_names                  = {{ getenv "MYSQL_LOWER_CASE_TABLE_NAME" "0" }}
+
 symbolic-links                          = 0
 default_storage_engine                  = {{ getenv "MYSQL_DEFAULT_STORAGE_ENGINE" "InnoDB" }}
 

--- a/10/templates/10.3/my.cnf.tmpl
+++ b/10/templates/10.3/my.cnf.tmpl
@@ -41,6 +41,8 @@ init_connect                            = '{{ getenv "MYSQL_INIT_CONNECT" "SET N
 character_set_server                    = {{ getenv "MYSQL_CHARACTER_SET_SERVER" "utf8" }}
 character_set_filesystem                = {{ getenv "MYSQL_CHARACTER_SET_FILESYSTEM" "utf8" }}
 
+lower_case_table_names                  = {{ getenv "MYSQL_LOWER_CASE_TABLE_NAME" "0" }}
+
 symbolic-links                          = 0
 default_storage_engine                  = {{ getenv "MYSQL_DEFAULT_STORAGE_ENGINE" "InnoDB" }}
 

--- a/10/templates/10.4/my.cnf.tmpl
+++ b/10/templates/10.4/my.cnf.tmpl
@@ -42,6 +42,8 @@ init_connect                            = '{{ getenv "MYSQL_INIT_CONNECT" "SET N
 character_set_server                    = {{ getenv "MYSQL_CHARACTER_SET_SERVER" "utf8" }}
 character_set_filesystem                = {{ getenv "MYSQL_CHARACTER_SET_FILESYSTEM" "utf8" }}
 
+lower_case_table_names                  = {{ getenv "MYSQL_LOWER_CASE_TABLE_NAME" "0" }}
+
 symbolic-links                          = 0
 {{- if getenv "WSREP_ON" }}
 default_storage_engine                  = InnoDB

--- a/10/templates/10.5/my.cnf.tmpl
+++ b/10/templates/10.5/my.cnf.tmpl
@@ -42,6 +42,8 @@ init_connect                            = '{{ getenv "MYSQL_INIT_CONNECT" "SET N
 character_set_server                    = {{ getenv "MYSQL_CHARACTER_SET_SERVER" "utf8mb4" }}
 character_set_filesystem                = {{ getenv "MYSQL_CHARACTER_SET_FILESYSTEM" "binary" }}
 
+lower_case_table_names                  = {{ getenv "MYSQL_LOWER_CASE_TABLE_NAME" "0" }}
+
 symbolic-links                          = 0
 {{- if getenv "WSREP_ON" }}
 default_storage_engine                  = InnoDB

--- a/10/templates/10.6/my.cnf.tmpl
+++ b/10/templates/10.6/my.cnf.tmpl
@@ -42,6 +42,8 @@ init_connect                            = '{{ getenv "MYSQL_INIT_CONNECT" "SET N
 character_set_server                    = {{ getenv "MYSQL_CHARACTER_SET_SERVER" "utf8mb4" }}
 character_set_filesystem                = {{ getenv "MYSQL_CHARACTER_SET_FILESYSTEM" "binary" }}
 
+lower_case_table_names                  = {{ getenv "MYSQL_LOWER_CASE_TABLE_NAME" "0" }}
+
 symbolic-links                          = 0
 {{- if getenv "WSREP_ON" }}
 default_storage_engine                  = InnoDB

--- a/README.md
+++ b/README.md
@@ -75,6 +75,7 @@ All images built for `linux/amd64`
 | [`MYSQL_JOIN_BUFFER_SIZE`]               | `8M`                 | `8M`              | `8M`              | `8M`              |
 | [`MYSQL_LOG_WARNINGS`]                   | `2`                  | `2`               | `2`               | `2`               |
 | [`MYSQL_LONG_QUERY_TIME`]                | `2`                  | `2`               | `2`               | `2`               |
+| [`MYSQL_LOWER_CASE_TABLE_NAME`           | `0`                  | `0`               | `0`               | `0`               |
 | [`MYSQL_MAX_ALLOWED_PACKET`]             | `256M`               | `256M`            | `256M`            | `256M`            |
 | [`MYSQL_MAX_CONNECT_ERRORS`]             | `100000`             | `100000`          | `100000`          | `100000`          |
 | [`MYSQL_MAX_CONNECTIONS`]                | `50`                 | `50`              | `50`              | `50`              |
@@ -265,9 +266,9 @@ commands:
     query query [db user password host]
     query-silent query [db user password host]
     query-root query [db root_password host]
-    check-ready [root_password host max_try wait_seconds]  
-    mysql-upgrade [root_password host]  
-    mysql-check [root_password host db]  
+    check-ready [root_password host max_try wait_seconds]
+    mysql-upgrade [root_password host]
+    mysql-check [root_password host db]
     create-db name [charset collation]
     drop-db name
     create-user username password
@@ -332,6 +333,7 @@ Deploy MariaDB to your own server via [![Wodby](https://www.google.com/s2/favico
 [`MYSQL_JOIN_BUFFER_SIZE`]: https://mariadb.com/kb/en/library/server-system-variables#join_buffer_size
 [`MYSQL_LOG_WARNINGS`]: https://mariadb.com/kb/en/library/server-system-variables/#log_warnings
 [`MYSQL_LONG_QUERY_TIME`]: https://mariadb.com/kb/en/library/server-system-variables#long_query_time
+[`MYSQL_LOWER_CASE_TABLE_NAME`]: https://mariadb.com/kb/en/server-system-variables/#lower_case_table_names
 [`MYSQL_MAX_ALLOWED_PACKET`]: https://mariadb.com/kb/en/library/server-system-variables#max_allowed_packet
 [`MYSQL_MAX_CONNECT_ERRORS`]: https://mariadb.com/kb/en/library/server-system-variables#max_connect_errors
 [`MYSQL_MAX_CONNECTIONS`]: https://mariadb.com/kb/en/library/server-system-variables#max_connections


### PR DESCRIPTION
Permit to set mariaDB property `lower_case_table_names`, usefull on some case that automated generation tools create table name in an upper case and that other use only lowercase table names. This problem appear with linux systems.