### PR TITLE
Reject invalid MariaDB initialization files

### DIFF
--- a/10/bin/init_mariadb
+++ b/10/bin/init_mariadb
@@ -60,6 +60,27 @@ _is_sourced() {
 # usage: docker_process_init_files [file [file [...]]]
 #    ie: docker_process_init_files /always-initdb.d/*
 # process initializer files, based on file extensions
+docker_process_init_archive() {
+	local archive="$1"
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local archive_copy="$tmp_dir/$(basename "$archive")"
+	local extract_dir="$tmp_dir/extracted"
+	cp "$archive" "$archive_copy"
+	get_archive "$archive_copy" "$extract_dir" "zip tgz tar.gz gz"
+
+	local -a sql_files=()
+	mapfile -d '' sql_files < <(find "$extract_dir" -type f \( -name '*.sql' -o -name '*.mysql' \) -print0)
+	if [ "${#sql_files[@]}" -ne 1 ]; then
+		local count="${#sql_files[@]}"
+		rm -rf "$tmp_dir"
+		mariadb_error "$0: expected exactly one .sql or .mysql file in $archive; found $count"
+	fi
+
+	docker_process_sql < "${sql_files[0]}"
+	rm -rf "$tmp_dir"
+}
+
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
@@ -79,10 +100,10 @@ docker_process_init_files() {
 					. "$f"
 				fi
 				;;
-			*.sql)    mariadb_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
-			*.sql.gz) mariadb_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz) mariadb_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*)        mariadb_warn "$0: ignoring $f" ;;
+			*.sql)                    mariadb_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
+			*.tar.gz|*.tgz|*.zip|*.gz) mariadb_note "$0: running $f"; docker_process_init_archive "$f"; echo ;;
+			*.sql.xz)                 mariadb_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
+			*)        mariadb_error "$0: unsupported initialization file $f" ;;
 		esac
 		echo
 	done

--- a/10/tests/run.sh
+++ b/10/tests/run.sh
@@ -12,6 +12,23 @@ export MYSQL_PASSWORD='mariadb'
 export MYSQL_DATABASE='mariadb'
 export MYSQL_HOST='mariadb'
 
+unsupported_init_dir="$(mktemp -d)"
+touch "${unsupported_init_dir}/database.dump"
+if docker run --rm \
+	-e MYSQL_RANDOM_ROOT_PASSWORD=1 \
+	-v "${unsupported_init_dir}:/docker-entrypoint-initdb.d:ro" \
+	"${IMAGE}" > "${unsupported_init_dir}/output.log" 2>&1; then
+	echo "Unsupported initialization file was accepted" >&2
+	exit 1
+fi
+grep -q 'unsupported initialization file /docker-entrypoint-initdb.d/database.dump' "${unsupported_init_dir}/output.log"
+rm -rf "${unsupported_init_dir}"
+
+archive_init_dir="$(mktemp -d)"
+echo 'CREATE TABLE mariadb.archive_init_test (id INT);' > "${archive_init_dir}/database.sql"
+tar -czf "${archive_init_dir}/database.tar.gz" -C "${archive_init_dir}" database.sql
+rm "${archive_init_dir}/database.sql"
+
 cid="$(
 	docker run -d \
 	    -e DEBUG \
@@ -20,10 +37,11 @@ cid="$(
 		-e MYSQL_PASSWORD \
 		-e MYSQL_DATABASE \
 		-e MARIADB_PLUGIN_LOAD=auth_pam \
+		-v "${archive_init_dir}:/docker-entrypoint-initdb.d:ro" \
 		--name "${MYSQL_HOST}" \
 		"${IMAGE}"
 )"
-trap "docker rm -vf ${cid} > /dev/null" EXIT
+trap "docker rm -vf ${cid} > /dev/null; rm -rf ${archive_init_dir}" EXIT
 
 mariadb() {
 	docker run --rm -i \
@@ -36,6 +54,7 @@ mariadb() {
 }
 
 mariadb make check-ready delay_seconds=5 wait_seconds=5 max_try=12
+[ "$(mariadb make query-silent query='SELECT COUNT(*) FROM archive_init_test')" = 0 ]
 mariadb make mysql-upgrade
 mariadb make mysql-check
 

--- a/11/bin/init_mariadb
+++ b/11/bin/init_mariadb
@@ -60,6 +60,27 @@ _is_sourced() {
 # usage: docker_process_init_files [file [file [...]]]
 #    ie: docker_process_init_files /always-initdb.d/*
 # process initializer files, based on file extensions
+docker_process_init_archive() {
+	local archive="$1"
+	local tmp_dir
+	tmp_dir="$(mktemp -d)"
+	local archive_copy="$tmp_dir/$(basename "$archive")"
+	local extract_dir="$tmp_dir/extracted"
+	cp "$archive" "$archive_copy"
+	get_archive "$archive_copy" "$extract_dir" "zip tgz tar.gz gz"
+
+	local -a sql_files=()
+	mapfile -d '' sql_files < <(find "$extract_dir" -type f \( -name '*.sql' -o -name '*.mysql' \) -print0)
+	if [ "${#sql_files[@]}" -ne 1 ]; then
+		local count="${#sql_files[@]}"
+		rm -rf "$tmp_dir"
+		mariadb_error "$0: expected exactly one .sql or .mysql file in $archive; found $count"
+	fi
+
+	docker_process_sql < "${sql_files[0]}"
+	rm -rf "$tmp_dir"
+}
+
 docker_process_init_files() {
 	# mysql here for backwards compatibility "${mysql[@]}"
 	mysql=( docker_process_sql )
@@ -79,10 +100,10 @@ docker_process_init_files() {
 					. "$f"
 				fi
 				;;
-			*.sql)    mariadb_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
-			*.sql.gz) mariadb_note "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
-			*.sql.xz) mariadb_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
-			*)        mariadb_warn "$0: ignoring $f" ;;
+			*.sql)                    mariadb_note "$0: running $f"; docker_process_sql < "$f"; echo ;;
+			*.tar.gz|*.tgz|*.zip|*.gz) mariadb_note "$0: running $f"; docker_process_init_archive "$f"; echo ;;
+			*.sql.xz)                 mariadb_note "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
+			*)        mariadb_error "$0: unsupported initialization file $f" ;;
 		esac
 		echo
 	done

--- a/11/tests/run.sh
+++ b/11/tests/run.sh
@@ -12,6 +12,23 @@ export MYSQL_PASSWORD='mariadb'
 export MYSQL_DATABASE='mariadb'
 export MYSQL_HOST='mariadb'
 
+unsupported_init_dir="$(mktemp -d)"
+touch "${unsupported_init_dir}/database.dump"
+if docker run --rm \
+	-e MYSQL_RANDOM_ROOT_PASSWORD=1 \
+	-v "${unsupported_init_dir}:/docker-entrypoint-initdb.d:ro" \
+	"${IMAGE}" > "${unsupported_init_dir}/output.log" 2>&1; then
+	echo "Unsupported initialization file was accepted" >&2
+	exit 1
+fi
+grep -q 'unsupported initialization file /docker-entrypoint-initdb.d/database.dump' "${unsupported_init_dir}/output.log"
+rm -rf "${unsupported_init_dir}"
+
+archive_init_dir="$(mktemp -d)"
+echo 'CREATE TABLE mariadb.archive_init_test (id INT);' > "${archive_init_dir}/database.sql"
+tar -czf "${archive_init_dir}/database.tar.gz" -C "${archive_init_dir}" database.sql
+rm "${archive_init_dir}/database.sql"
+
 cid="$(
 	docker run -d \
 	    -e DEBUG \
@@ -20,10 +37,11 @@ cid="$(
 		-e MYSQL_PASSWORD \
 		-e MYSQL_DATABASE \
 		-e MARIADB_PLUGIN_LOAD=auth_pam \
+		-v "${archive_init_dir}:/docker-entrypoint-initdb.d:ro" \
 		--name "${MYSQL_HOST}" \
 		"${IMAGE}"
 )"
-trap "docker rm -vf ${cid} > /dev/null" EXIT
+trap "docker rm -vf ${cid} > /dev/null; rm -rf ${archive_init_dir}" EXIT
 
 mariadb() {
 	docker run --rm -i \
@@ -36,6 +54,7 @@ mariadb() {
 }
 
 mariadb make check-ready delay_seconds=5 wait_seconds=5 max_try=12
+[ "$(mariadb make query-silent query='SELECT COUNT(*) FROM archive_init_test')" = 0 ]
 mariadb make mysql-upgrade
 mariadb make mysql-check
 

--- a/README.md
+++ b/README.md
@@ -248,6 +248,11 @@ Refer to the [documentation](https://galeracluster.com/library/documentation/arb
 
 ## Orchestration Actions
 
+During first-time database initialization, files mounted under `/docker-entrypoint-initdb.d` must use one of the
+supported extensions: `.sh`, `.sql`, `.sql.gz`, `.sql.xz`, `.gz`, `.tgz`, `.tar.gz`, or `.zip`. Archives must contain
+exactly one `.sql` or `.mysql` file. The container exits with an error for unsupported or malformed files so that a
+failed database import cannot be mistaken for a successful empty-database startup.
+
 Usage:
 
 ```


### PR DESCRIPTION
## Summary

- fail first-time database startup when an initialization file has an unsupported extension
- extract `.gz`, `.tgz`, `.tar.gz`, and `.zip` imports and require exactly one SQL payload
- preserve direct `.sql`, `.sql.xz`, and shell initialization support
- cover both MariaDB 10 and 11 image lines

## Validation

- `bash -n 10/bin/init_mariadb 11/bin/init_mariadb 10/tests/run.sh 11/tests/run.sh`
- direct unsupported-file checks against both entrypoint scripts
- image integration tests extended for rejected files and supported tar archives

## Before merge

Run the full image build/test matrix. The required versioned images are not available locally, and the existing image workflow runs only after pushes to `master`, not for pull requests.