### PR TITLE
Fix initialization archive tests on ARM runners

### DIFF
--- a/10/bin/init_mariadb
+++ b/10/bin/init_mariadb
@@ -70,7 +70,13 @@ docker_process_init_archive() {
 	get_archive "$archive_copy" "$extract_dir" "zip tgz tar.gz gz"
 
 	local -a sql_files=()
-	mapfile -d '' sql_files < <(find "$extract_dir" -type f \( -name '*.sql' -o -name '*.mysql' \) -print0)
+	mapfile -d '' sql_files < <(
+		find "$extract_dir" -type f \
+			\( -name '*.sql' -o -name '*.mysql' \) \
+			! -name '._*' \
+			! -path '*/__MACOSX/*' \
+			-print0
+	)
 	if [ "${#sql_files[@]}" -ne 1 ]; then
 		local count="${#sql_files[@]}"
 		rm -rf "$tmp_dir"

--- a/10/tests/run.sh
+++ b/10/tests/run.sh
@@ -13,18 +13,25 @@ export MYSQL_DATABASE='mariadb'
 export MYSQL_HOST='mariadb'
 
 unsupported_init_dir="$(mktemp -d)"
+unsupported_init_output="$(mktemp)"
+chmod 755 "${unsupported_init_dir}"
 touch "${unsupported_init_dir}/database.dump"
 if docker run --rm \
 	-e MYSQL_RANDOM_ROOT_PASSWORD=1 \
 	-v "${unsupported_init_dir}:/docker-entrypoint-initdb.d:ro" \
-	"${IMAGE}" > "${unsupported_init_dir}/output.log" 2>&1; then
+	"${IMAGE}" > "${unsupported_init_output}" 2>&1; then
 	echo "Unsupported initialization file was accepted" >&2
 	exit 1
 fi
-grep -q 'unsupported initialization file /docker-entrypoint-initdb.d/database.dump' "${unsupported_init_dir}/output.log"
+if ! grep -q 'unsupported initialization file /docker-entrypoint-initdb.d/database.dump' "${unsupported_init_output}"; then
+	cat "${unsupported_init_output}" >&2
+	exit 1
+fi
 rm -rf "${unsupported_init_dir}"
+rm "${unsupported_init_output}"
 
 archive_init_dir="$(mktemp -d)"
+chmod 755 "${archive_init_dir}"
 echo 'CREATE TABLE mariadb.archive_init_test (id INT);' > "${archive_init_dir}/database.sql"
 tar -czf "${archive_init_dir}/database.tar.gz" -C "${archive_init_dir}" database.sql
 rm "${archive_init_dir}/database.sql"

--- a/11/bin/init_mariadb
+++ b/11/bin/init_mariadb
@@ -70,7 +70,13 @@ docker_process_init_archive() {
 	get_archive "$archive_copy" "$extract_dir" "zip tgz tar.gz gz"
 
 	local -a sql_files=()
-	mapfile -d '' sql_files < <(find "$extract_dir" -type f \( -name '*.sql' -o -name '*.mysql' \) -print0)
+	mapfile -d '' sql_files < <(
+		find "$extract_dir" -type f \
+			\( -name '*.sql' -o -name '*.mysql' \) \
+			! -name '._*' \
+			! -path '*/__MACOSX/*' \
+			-print0
+	)
 	if [ "${#sql_files[@]}" -ne 1 ]; then
 		local count="${#sql_files[@]}"
 		rm -rf "$tmp_dir"

--- a/11/tests/run.sh
+++ b/11/tests/run.sh
@@ -13,18 +13,25 @@ export MYSQL_DATABASE='mariadb'
 export MYSQL_HOST='mariadb'
 
 unsupported_init_dir="$(mktemp -d)"
+unsupported_init_output="$(mktemp)"
+chmod 755 "${unsupported_init_dir}"
 touch "${unsupported_init_dir}/database.dump"
 if docker run --rm \
 	-e MYSQL_RANDOM_ROOT_PASSWORD=1 \
 	-v "${unsupported_init_dir}:/docker-entrypoint-initdb.d:ro" \
-	"${IMAGE}" > "${unsupported_init_dir}/output.log" 2>&1; then
+	"${IMAGE}" > "${unsupported_init_output}" 2>&1; then
 	echo "Unsupported initialization file was accepted" >&2
 	exit 1
 fi
-grep -q 'unsupported initialization file /docker-entrypoint-initdb.d/database.dump' "${unsupported_init_dir}/output.log"
+if ! grep -q 'unsupported initialization file /docker-entrypoint-initdb.d/database.dump' "${unsupported_init_output}"; then
+	cat "${unsupported_init_output}" >&2
+	exit 1
+fi
 rm -rf "${unsupported_init_dir}"
+rm "${unsupported_init_output}"
 
 archive_init_dir="$(mktemp -d)"
+chmod 755 "${archive_init_dir}"
 echo 'CREATE TABLE mariadb.archive_init_test (id INT);' > "${archive_init_dir}/database.sql"
 tar -czf "${archive_init_dir}/database.tar.gz" -C "${archive_init_dir}" database.sql
 rm "${archive_init_dir}/database.sql"


### PR DESCRIPTION
## Summary

- make bind-mounted initialization fixtures readable by the container user
- capture negative-test output outside the initialization directory and print it on assertion failure
- ignore macOS AppleDouble metadata when selecting an SQL file from an archive

## Validation

- `bash -n 10/bin/init_mariadb 10/tests/run.sh 11/bin/init_mariadb 11/tests/run.sh`
- `git diff --check`
- full `11/tests/run.sh` suite against a local MariaDB 11 image with the updated initialization script