### PR TITLE
Fix MariaDB 11 DuckDB build dependency

### DIFF
--- a/11/Dockerfile
+++ b/11/Dockerfile
@@ -40,6 +40,7 @@ RUN set -xe; \
         build-base \
         cmake \
         coreutils \
+        git \
         gnupg \
         libaio-dev \
         linux-pam-dev \


### PR DESCRIPTION
## Summary
- install git as a temporary MariaDB 11 build dependency
- allow the upstream DuckDB patch step to run
- preserve the runtime image because the virtual build-dependency package is purged

## Root cause
MariaDB 11.4.13 and 11.8.9 invoke git apply while patching the bundled DuckDB extension. The image did not install git, so both version builds failed with git: command not found.

Failing run: https://github.com/wodby/mariadb/actions/runs/32803402640

## Validation
- built the full MariaDB 11.4.13 image successfully
- ran make test successfully
- confirmed git is absent from the final runtime image