### PR TITLE
Add streaming database backups

### DIFF
--- a/10/bin/actions.mk
+++ b/10/bin/actions.mk
@@ -30,6 +30,11 @@ backup:
 	backup $(root_password) $(host) $(db) $(filepath) $(ignore)
 .PHONY: backup
 
+backup-stream:
+	$(call check_defined, stream_path, status_path)
+	backup_stream $(root_password) $(host) $(db) $(stream_path) $(status_path) $(ignore)
+.PHONY: backup-stream
+
 query:
 	$(call check_defined, query)
 	mariadb -u$(user) -p$(password) -h$(host) -e "$(query)" $(db)

--- a/10/bin/backup_stream
+++ b/10/bin/backup_stream
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -eEo pipefail
+
+if [[ -n "${DEBUG}" ]]; then
+    set -x
+fi
+
+root_password=$1
+host=$2
+db=$3
+stream_path=$4
+status_path=$5
+ignore_tables=$6
+
+write_status() {
+    exit_code=$?
+    status_tmp="${status_path}.tmp.$$"
+    printf '%s\n' "${exit_code}" > "${status_tmp}"
+    mv "${status_tmp}" "${status_path}"
+}
+trap write_status EXIT
+
+# Open the FIFO before any database work so the uploader receives EOF even if
+# preparing the dump fails before the first byte is produced.
+exec 3> "${stream_path}"
+
+ignore=()
+
+IFS=';' read -ra ADDR <<< "${ignore_tables}"
+for table in "${ADDR[@]}"; do
+    if echo "${table}" | grep -q "%"; then
+        out=$(mariadb --silent -h"${host}" -uroot -p"${root_password}" -e "SHOW TABLES LIKE '${table}'" "${db}")
+        tables=(${out//$'\n'/ })
+
+        for t in "${tables[@]}"; do
+            ignore+=("--ignore-table=${db}.${t}")
+        done
+    else
+        ignore+=("--ignore-table=${db}.${table}")
+    fi
+done
+
+{
+    mariadb-dump -h"${host}" -uroot -p"${root_password}" \
+        --single-transaction --no-data --allow-keywords --skip-triggers \
+        "${db}"
+
+    mariadb-dump -h"${host}" -uroot -p"${root_password}" \
+        --single-transaction --no-create-info "${ignore[@]}" --allow-keywords \
+        "${db}"
+} | gzip >&3

--- a/10/tests/run.sh
+++ b/10/tests/run.sh
@@ -116,6 +116,48 @@ mariadb make mysql-check
 [ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test1')" = 0 ]
 [ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test2')" = 0 ]
 
+stream_dir="$(mktemp -d)"
+chmod 777 "${stream_dir}"
+docker run --rm \
+    -e MYSQL_USER -e MYSQL_ROOT_PASSWORD -e MYSQL_PASSWORD -e MYSQL_DATABASE \
+    -v "${stream_dir}:/stream" \
+    --link "${MYSQL_HOST}":"${MYSQL_HOST}" \
+    "${IMAGE}" bash -ceu '
+        mkfifo /stream/data
+        touch /stream/status
+        chmod 666 /stream/data /stream/status
+        cat /stream/data > /stream/export.sql.gz &
+        reader=$!
+        make -f /usr/local/bin/actions.mk backup-stream \
+            host="'"${MYSQL_HOST}"'" \
+            ignore="test1;test2;cache_%;test3" \
+            stream_path=/stream/data \
+            status_path=/stream/status
+        wait "${reader}"
+        test "$(cat /stream/status)" = 0
+
+        rm /stream/data /stream/status
+        mkfifo /stream/data
+        touch /stream/status
+        chmod 666 /stream/data /stream/status
+        cat /stream/data >/dev/null &
+        reader=$!
+        if make -f /usr/local/bin/actions.mk backup-stream \
+            host="'"${MYSQL_HOST}"'" \
+            db=missing_stream_backup_database \
+            stream_path=/stream/data \
+            status_path=/stream/status; then
+            exit 1
+        fi
+        wait "${reader}"
+        test "$(cat /stream/status)" != 0
+    '
+mariadb make import source="${stream_dir}/export.sql.gz"
+[ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test')" = 1 ]
+[ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test1')" = 0 ]
+[ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test2')" = 0 ]
+rm -rf "${stream_dir}"
+
 mariadb make import source="https://s3.amazonaws.com/wodby-sample-files/mariadb-import-test/export.zip"
 mariadb make import source="https://s3.amazonaws.com/wodby-sample-files/mariadb-import-test/export.tar.gz"
 mariadb make mysql-check

--- a/11/bin/actions.mk
+++ b/11/bin/actions.mk
@@ -30,6 +30,11 @@ backup:
 	backup $(root_password) $(host) $(db) $(filepath) $(ignore)
 .PHONY: backup
 
+backup-stream:
+	$(call check_defined, stream_path, status_path)
+	backup_stream $(root_password) $(host) $(db) $(stream_path) $(status_path) $(ignore)
+.PHONY: backup-stream
+
 query:
 	$(call check_defined, query)
 	mariadb -u$(user) -p$(password) -h$(host) -e "$(query)" $(db)

--- a/11/bin/backup_stream
+++ b/11/bin/backup_stream
@@ -1,0 +1,52 @@
+#!/usr/bin/env bash
+
+set -eEo pipefail
+
+if [[ -n "${DEBUG}" ]]; then
+    set -x
+fi
+
+root_password=$1
+host=$2
+db=$3
+stream_path=$4
+status_path=$5
+ignore_tables=$6
+
+write_status() {
+    exit_code=$?
+    status_tmp="${status_path}.tmp.$$"
+    printf '%s\n' "${exit_code}" > "${status_tmp}"
+    mv "${status_tmp}" "${status_path}"
+}
+trap write_status EXIT
+
+# Open the FIFO before any database work so the uploader receives EOF even if
+# preparing the dump fails before the first byte is produced.
+exec 3> "${stream_path}"
+
+ignore=()
+
+IFS=';' read -ra ADDR <<< "${ignore_tables}"
+for table in "${ADDR[@]}"; do
+    if echo "${table}" | grep -q "%"; then
+        out=$(mariadb --silent -h"${host}" -uroot -p"${root_password}" -e "SHOW TABLES LIKE '${table}'" "${db}")
+        tables=(${out//$'\n'/ })
+
+        for t in "${tables[@]}"; do
+            ignore+=("--ignore-table=${db}.${t}")
+        done
+    else
+        ignore+=("--ignore-table=${db}.${table}")
+    fi
+done
+
+{
+    mariadb-dump -h"${host}" -uroot -p"${root_password}" \
+        --single-transaction --no-data --allow-keywords --skip-triggers \
+        "${db}"
+
+    mariadb-dump -h"${host}" -uroot -p"${root_password}" \
+        --single-transaction --no-create-info "${ignore[@]}" --allow-keywords \
+        "${db}"
+} | gzip >&3

--- a/11/tests/run.sh
+++ b/11/tests/run.sh
@@ -116,6 +116,48 @@ mariadb make mysql-check
 [ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test1')" = 0 ]
 [ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test2')" = 0 ]
 
+stream_dir="$(mktemp -d)"
+chmod 777 "${stream_dir}"
+docker run --rm \
+    -e MYSQL_USER -e MYSQL_ROOT_PASSWORD -e MYSQL_PASSWORD -e MYSQL_DATABASE \
+    -v "${stream_dir}:/stream" \
+    --link "${MYSQL_HOST}":"${MYSQL_HOST}" \
+    "${IMAGE}" bash -ceu '
+        mkfifo /stream/data
+        touch /stream/status
+        chmod 666 /stream/data /stream/status
+        cat /stream/data > /stream/export.sql.gz &
+        reader=$!
+        make -f /usr/local/bin/actions.mk backup-stream \
+            host="'"${MYSQL_HOST}"'" \
+            ignore="test1;test2;cache_%;test3" \
+            stream_path=/stream/data \
+            status_path=/stream/status
+        wait "${reader}"
+        test "$(cat /stream/status)" = 0
+
+        rm /stream/data /stream/status
+        mkfifo /stream/data
+        touch /stream/status
+        chmod 666 /stream/data /stream/status
+        cat /stream/data >/dev/null &
+        reader=$!
+        if make -f /usr/local/bin/actions.mk backup-stream \
+            host="'"${MYSQL_HOST}"'" \
+            db=missing_stream_backup_database \
+            stream_path=/stream/data \
+            status_path=/stream/status; then
+            exit 1
+        fi
+        wait "${reader}"
+        test "$(cat /stream/status)" != 0
+    '
+mariadb make import source="${stream_dir}/export.sql.gz"
+[ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test')" = 1 ]
+[ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test1')" = 0 ]
+[ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test2')" = 0 ]
+rm -rf "${stream_dir}"
+
 mariadb make import source="https://s3.amazonaws.com/wodby-sample-files/mariadb-import-test/export.zip"
 mariadb make import source="https://s3.amazonaws.com/wodby-sample-files/mariadb-import-test/export.tar.gz"
 mariadb make mysql-check


### PR DESCRIPTION
MariaDB backups currently write the entire compressed dump into the database volume before it can be uploaded. This change adds a separate streaming action that writes the dump to a FIFO, while leaving the established staged action unchanged for existing consumers.

## What changed

- add `backup_stream` scripts for the MariaDB 10 and 11 image families
- add the `backup-stream` Make target without changing `backup`
- publish producer completion through an atomic status file
- open the FIFO before database preparation so early failures still deliver EOF to the uploader
- add successful restore and failed-producer coverage to both image test suites

## Validation

- `bash -n 10/bin/backup_stream 11/bin/backup_stream 10/tests/run.sh 11/tests/run.sh`
- `git diff --check`

The Docker-backed database matrix was not run locally; the new cases execute as part of the image build workflow.

## Release

After merge and successful image builds, create annotated release tag `3.36.0`.
