### PR TITLE
Fix MariaDB streaming backup invocation

### DIFF
--- a/10/bin/actions.mk
+++ b/10/bin/actions.mk
@@ -32,7 +32,7 @@ backup:
 
 backup-stream:
 	$(call check_defined, stream_path, status_path)
-	backup_stream $(root_password) $(host) $(db) $(stream_path) $(status_path) $(ignore)
+	backup_stream $(root_password) $(host) $(db) $(stream_path) $(status_path) "$(ignore)"
 .PHONY: backup-stream
 
 query:

--- a/10/tests/run.sh
+++ b/10/tests/run.sh
@@ -152,7 +152,12 @@ docker run --rm \
         wait "${reader}"
         test "$(cat /stream/status)" != 0
     '
-mariadb make import source="${stream_dir}/export.sql.gz"
+docker run --rm -i \
+    -e DEBUG -e MYSQL_USER -e MYSQL_ROOT_PASSWORD -e MYSQL_PASSWORD -e MYSQL_DATABASE \
+    -v "${stream_dir}:/stream" \
+    --link "${MYSQL_HOST}":"${MYSQL_HOST}" \
+    "${IMAGE}" \
+    make import source=/stream/export.sql.gz host="${MYSQL_HOST}"
 [ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test')" = 1 ]
 [ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test1')" = 0 ]
 [ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test2')" = 0 ]

--- a/11/bin/actions.mk
+++ b/11/bin/actions.mk
@@ -32,7 +32,7 @@ backup:
 
 backup-stream:
 	$(call check_defined, stream_path, status_path)
-	backup_stream $(root_password) $(host) $(db) $(stream_path) $(status_path) $(ignore)
+	backup_stream $(root_password) $(host) $(db) $(stream_path) $(status_path) "$(ignore)"
 .PHONY: backup-stream
 
 query:

--- a/11/tests/run.sh
+++ b/11/tests/run.sh
@@ -152,7 +152,12 @@ docker run --rm \
         wait "${reader}"
         test "$(cat /stream/status)" != 0
     '
-mariadb make import source="${stream_dir}/export.sql.gz"
+docker run --rm -i \
+    -e DEBUG -e MYSQL_USER -e MYSQL_ROOT_PASSWORD -e MYSQL_PASSWORD -e MYSQL_DATABASE \
+    -v "${stream_dir}:/stream" \
+    --link "${MYSQL_HOST}":"${MYSQL_HOST}" \
+    "${IMAGE}" \
+    make import source=/stream/export.sql.gz host="${MYSQL_HOST}"
 [ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test')" = 1 ]
 [ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test1')" = 0 ]
 [ "$(mariadb make query-silent query='SELECT COUNT(*) FROM test2')" = 0 ]


### PR DESCRIPTION
The MariaDB streaming backup build failed for two reasons: semicolon-separated table exclusions were expanded by the shell as separate commands, and the restore test passed a host temporary path to a container where that path was not mounted. This change keeps the exclusion list as one producer argument and mounts the generated archive at the path used by the import helper.

The same corrections are applied to the MariaDB 10 and MariaDB 11 implementations.

## Validation

- MariaDB 10.11 full test suite
- MariaDB 11.4 full test suite
- `bash -n 10/tests/run.sh`
- `bash -n 11/tests/run.sh`
- `git diff --check`
