### PR TITLE
Fix backup exclusion argument quoting

### DIFF
--- a/10/bin/actions.mk
+++ b/10/bin/actions.mk
@@ -14,7 +14,7 @@ host ?= localhost
 max_try ?= 1
 wait_seconds ?= 1
 delay_seconds ?= 0
-ignore ?= ""
+ignore ?=
 charset ?= utf8
 collation ?= utf8_general_ci
 
@@ -27,7 +27,7 @@ import:
 
 backup:
 	$(call check_defined, filepath)
-	backup $(root_password) $(host) $(db) $(filepath) $(ignore)
+	backup $(root_password) $(host) $(db) $(filepath) "$(ignore)"
 .PHONY: backup
 
 backup-stream:

--- a/10/tests/run.sh
+++ b/10/tests/run.sh
@@ -104,7 +104,7 @@ mariadb make query query="INSERT INTO test1 VALUES (1, 2, 'hello')"
 mariadb make query query="INSERT INTO test2 VALUES (1, 2, 'hello!')"
 mariadb make mysql-check
 
-mariadb make backup filepath="/mnt/backups/export.sql.gz" 'ignore="test1;test2;cache_%;test3"'
+mariadb make backup filepath="/mnt/backups/export.sql.gz" ignore="test1;test2;cache_%;test3"
 mariadb make query query="DROP DATABASE mariadb"
 mariadb make import source="/mnt/backups/export.sql.gz"
 mariadb make mysql-check

--- a/11/bin/actions.mk
+++ b/11/bin/actions.mk
@@ -14,7 +14,7 @@ host ?= localhost
 max_try ?= 1
 wait_seconds ?= 1
 delay_seconds ?= 0
-ignore ?= ""
+ignore ?=
 charset ?= utf8
 collation ?= utf8_general_ci
 
@@ -27,7 +27,7 @@ import:
 
 backup:
 	$(call check_defined, filepath)
-	backup $(root_password) $(host) $(db) $(filepath) $(ignore)
+	backup $(root_password) $(host) $(db) $(filepath) "$(ignore)"
 .PHONY: backup
 
 backup-stream:

--- a/11/tests/run.sh
+++ b/11/tests/run.sh
@@ -104,7 +104,7 @@ mariadb make query query="INSERT INTO test1 VALUES (1, 2, 'hello')"
 mariadb make query query="INSERT INTO test2 VALUES (1, 2, 'hello!')"
 mariadb make mysql-check
 
-mariadb make backup filepath="/mnt/backups/export.sql.gz" 'ignore="test1;test2;cache_%;test3"'
+mariadb make backup filepath="/mnt/backups/export.sql.gz" ignore="test1;test2;cache_%;test3"
 mariadb make query query="DROP DATABASE mariadb"
 mariadb make import source="/mnt/backups/export.sql.gz"
 mariadb make mysql-check


### PR DESCRIPTION
Semicolon-delimited backup exclusion lists did not have one consistent quoting boundary. The staged target relied on callers embedding quote characters, while the streaming target added another pair; manifest-driven streaming backups could therefore expose semicolons to the shell and fail by treating table names as commands.

This makes the MariaDB Make targets own shell quoting for both staged and streamed backups. Callers now pass raw `ignore` values, and the integration invocation exercises that contract directly.

## Summary

- quote the `ignore` value inside both MariaDB 10 and 11 staged backup recipes
- keep streaming backup quoting consistent with the staged path
- represent the empty default as an empty Make value instead of embedded quote characters
- exercise semicolon-delimited tables and wildcard exclusions through the raw Make-variable interface

## Validation

- MariaDB 10.11 integration suite passed against a stream-enabled image with the updated Makefile
- MariaDB 11.4 integration suite passed against a stream-enabled image with the updated Makefile
- both suites verified staged backup, streaming backup, restore, multiple exclusions, wildcard exclusions, and producer failure handling

## Rollout

Publish patched MariaDB image tags before publishing [wodby/service-mariadb#6](https://github.com/wodby/service-mariadb/pull/6).
